### PR TITLE
fix: ZkRegister object has no attribute 'hosts'

### DIFF
--- a/dubbo/client.py
+++ b/dubbo/client.py
@@ -120,16 +120,17 @@ class ZkRegister(object):
         :param hosts: Zookeeper的地址
         :param application_name: 当前客户端的名称
         """
+        self.hosts = {}
+        self.weights = {}
+        self.application_name = application_name
+        self.lock = threading.Lock()
+        
         zk = KazooClient(hosts=hosts)
         # 对zookeeper连接状态的监控
         zk.add_listener(self.state_listener)
         zk.start()
 
         self.zk = zk
-        self.hosts = {}
-        self.weights = {}
-        self.application_name = application_name
-        self.lock = threading.Lock()
 
     def state_listener(self, state):
         """


### PR DESCRIPTION
```
File "/Library/Python/2.7/site-packages/dubbo/client.py", line 157, in __resubscribe
    for interface in self.hosts.keys():
AttributeError: 'ZkRegister' object has no attribute 'hosts'
```